### PR TITLE
Change tx payload data structure

### DIFF
--- a/bounties/terra-wormhole/struct-vaa_data.md
+++ b/bounties/terra-wormhole/struct-vaa_data.md
@@ -51,7 +51,7 @@ The top numbers are the size of the data.&#x20;
             u256     amount
             [u8; 32] token_address
             u16      token_chain
-            [u8; 32] recipient
+            [u8; 40] recipient
             u16      recipient_chain
             u256     fee
     """


### PR DESCRIPTION
# Problem

The original post data structure was a 32-bytes length address; however, this is not true.

According to:
https://github.com/certusone/wormhole/blob/dev.v2/terra/contracts/token-bridge/src/state.rs
```rust
//     0   u256     amount
//     32  [u8; 32] token_address
//     64  u16      token_chain
//     66  [u8; 32] recipient
//     98  u16      recipient_chain
//     100 u256     fee

#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
pub struct TransferInfo {
    pub amount: (u128, u128),
    pub token_address: Vec<u8>,
    pub token_chain: u16,
    pub recipient: Vec<u8>,
    pub recipient_chain: u16,
    pub fee: (u128, u128),
}
```

Due to obtaining 32 bytes starting from index 66 according to the wormhole dev's comment making the address to be undecipherable. BinhaChon#0041 found that 40 bytes before `recipient_chain` required to translate back into terra human-readable address. 

I'm suspecting that the devs were just copy-pasting the `state.rs` and forgot to change the comment. As the `recipient` declared as `Vec<u8>`.

# Changes

- Change `[u8; 32] recipient` to `[u8; 40] recipient`

# Proposer

lambdadelta#7856

# Contributor

BinhaChon#0041